### PR TITLE
Update NibDesignable.swift

### DIFF
--- a/NibDesignable.swift
+++ b/NibDesignable.swift
@@ -76,6 +76,10 @@ public class NibDesignable: UIView {
         self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
         self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
     }
+    
+    override public func willMoveToSuperview(newSuperview: UIView?) {
+        layoutIfNeeded()
+    }
 }
 
 @IBDesignable


### PR DESCRIPTION
Useful for NibDesignable subclasses that rely on the frame/bounds of their subviews being accurate at runtime. For example, using: subview.layer.cornerRadius = subview.frame.size.height / 2.0. This doesn't work correctly without this addition.