### PR TITLE
Use protocol extension to reduce the amount of redundant code.

### DIFF
--- a/NibDesignable.swift
+++ b/NibDesignable.swift
@@ -23,13 +23,30 @@
 
 import UIKit
 
-extension UIView {
-
+public protocol NibDesignableProtocol: NSObjectProtocol {
+    var nibContainerView: UIView { get }
     // MARK: - Nib loading
 
     /**
     Called to load the nib in setupNib().
-    
+
+    - returns: UIView instance loaded from a nib file.
+    */
+    func loadNib() -> UIView
+    /**
+     Called in the default implementation of loadNib(). Default is class name.
+
+     - returns: Name of a single view nib file.
+     */
+    func nibName() -> String
+}
+
+extension NibDesignableProtocol {
+    // MARK: - Nib loading
+
+    /**
+    Called to load the nib in setupNib().
+
     - returns: UIView instance loaded from a nib file.
     */
     public func loadNib() -> UIView {
@@ -37,19 +54,40 @@ extension UIView {
         let nib = UINib(nibName: self.nibName(), bundle: bundle)
         return nib.instantiateWithOwner(self, options: nil)[0] as! UIView
     }
-    
+
+    // MARK: - Nib loading
+
     /**
-    Called in the default implementation of loadNib(). Default is class name.
-    
-    - returns: Name of a single view nib file.
+    Called in init(frame:) and init(aDecoder:) to load the nib and add it as a subview.
     */
+    private func setupNib() {
+        let view = self.loadNib()
+        self.nibContainerView.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let bindings = ["view": view]
+        self.nibContainerView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
+        self.nibContainerView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
+    }
+}
+
+extension UIView {
+    public var nibContainerView: UIView {
+        get {
+            return self
+        }
+    }
+    /**
+     Called in the default implementation of loadNib(). Default is class name.
+
+     - returns: Name of a single view nib file.
+     */
     public func nibName() -> String {
         return self.dynamicType.description().componentsSeparatedByString(".").last!
     }
 }
 
 @IBDesignable
-public class NibDesignable: UIView {
+public class NibDesignable: UIView, NibDesignableProtocol {
 
     // MARK: - Initializer
     override public init(frame: CGRect) {
@@ -62,54 +100,31 @@ public class NibDesignable: UIView {
         super.init(coder: aDecoder)
         self.setupNib()
     }
-
-    // MARK: - Nib loading
-
-    /**
-        Called in init(frame:) and init(aDecoder:) to load the nib and add it as a subview.
-    */
-    private func setupNib() {
-        let view = self.loadNib()
-        self.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        let bindings = ["view": view]
-        self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-        self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-    }
 }
 
 @IBDesignable
-public class NibDesignableTableViewCell: UITableViewCell {
-    
+public class NibDesignableTableViewCell: UITableViewCell, NibDesignableProtocol {
+    public override var nibContainerView: UIView {
+        get {
+            return self.contentView
+        }
+    }
+
     // MARK: - Initializer
     override public init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.setupNib()
     }
-    
+
     // MARK: - NSCoding
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setupNib()
     }
-    
-    // MARK: - Nib loading
-    
-    /**
-        Called in init(frame:) and init(aDecoder:) to load the nib and add it as a subview.
-    */
-    private func setupNib() {
-        let view = self.loadNib()
-        self.contentView.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        let bindings = ["view": view]
-        self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-        self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-    }
 }
 
 @IBDesignable
-public class NibDesignableControl: UIControl {
+public class NibDesignableControl: UIControl, NibDesignableProtocol {
 
     // MARK: - Initializer
     override public init(frame: CGRect) {
@@ -122,48 +137,25 @@ public class NibDesignableControl: UIControl {
         super.init(coder: aDecoder)
         self.setupNib()
     }
-
-    // MARK: - Nib loading
-
-    /**
-    Called in init(frame:) and init(aDecoder:) to load the nib and add it as a subview.
-    */
-    private func setupNib() {
-        let view = self.loadNib()
-        self.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        let bindings = ["view": view]
-        self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-        self.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-    }
 }
 
 @IBDesignable
-public class NibDesignableCollectionViewCell: UICollectionViewCell {
-    
+public class NibDesignableCollectionViewCell: UICollectionViewCell, NibDesignableProtocol {
+    public override var nibContainerView: UIView {
+        get {
+            return self.contentView
+        }
+    }
+
     // MARK: - Initializer
     override public init(frame: CGRect) {
         super.init(frame: frame)
         self.setupNib()
     }
-    
+
     // MARK: - NSCoding
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setupNib()
-    }
-    
-    // MARK: - Nib loading
-    
-    /**
-    Called in init(frame:) and init(aDecoder:) to load the nib and add it as a subview.
-    */
-    private func setupNib() {
-        let view = self.loadNib()
-        self.contentView.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        let bindings = ["view": view]
-        self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
-        self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options:NSLayoutFormatOptions(rawValue: 0), metrics:nil, views: bindings))
     }
 }

--- a/NibDesignable.swift
+++ b/NibDesignable.swift
@@ -24,6 +24,12 @@
 import UIKit
 
 public protocol NibDesignableProtocol: NSObjectProtocol {
+    /**
+     Identifies the view that will be the superview of the contents loaded from
+     the Nib. Referenced in setupNib().
+     
+     - returns: Superview for Nib contents. 
+     */
     var nibContainerView: UIView { get }
     // MARK: - Nib loading
 


### PR DESCRIPTION
Introduce nibContainerView property to support single implementation
of setupNib()